### PR TITLE
[SIV-5891] GTX encoding hotfix - sort dictionaries

### DIFF
--- a/Runtime/Chromia/PostchainClient/GTX/Gtx.cs
+++ b/Runtime/Chromia/PostchainClient/GTX/Gtx.cs
@@ -238,7 +238,7 @@ namespace Chromia.Postchain.Client
             }
         }
 
-        private Dictionary<TKey, TValue> SortDictionaryByKey<TKey, TValue>(Dictionary<TKey, TValue> dict)
+        private static Dictionary<TKey, TValue> SortDictionaryByKey<TKey, TValue>(Dictionary<TKey, TValue> dict)
         {
             var sortedArray = dict.OrderBy(kvp => kvp.Key).ToArray();
             var sortedDict = new Dictionary<TKey, TValue>();

--- a/Runtime/Chromia/PostchainClient/GTX/Gtx.cs
+++ b/Runtime/Chromia/PostchainClient/GTX/Gtx.cs
@@ -83,7 +83,7 @@ namespace Chromia.Postchain.Client
             {
                 gtxValue.Choice = GTXValueChoice.Dict;
 
-                var dict = (Dictionary<string, object>)arg;
+                var dict = SortDictionaryByKey((Dictionary<string, object>)arg);
 
                 gtxValue.Dict = new List<DictPair>();
                 foreach (var dictPair in dict)
@@ -236,6 +236,19 @@ namespace Chromia.Postchain.Client
             {
                 return 1;
             }
+        }
+
+        private Dictionary<TKey, TValue> SortDictionaryByKey<TKey, TValue>(Dictionary<TKey, TValue> dict)
+        {
+            var sortedArray = dict.OrderBy(kvp => kvp.Key).ToArray();
+            var sortedDict = new Dictionary<TKey, TValue>();
+
+            foreach (var (key, value) in sortedArray)
+            {
+                sortedDict[key] = value;
+            }
+
+            return sortedDict;
         }
     }
 }


### PR DESCRIPTION
Related to this [Jira ticket](https://myneighboralice.atlassian.net/browse/SIV-5891)

The fix is similar to the TypeScript fix here: https://bitbucket.org/chromawallet/postchain-client/pull-requests/68/sort-string-maps

Sorts the dictionaries of arguments.
Tested with MyNeighborAlice's `shop.buy_items` call.
